### PR TITLE
Fixing CoTW init for non default Mods folder

### DIFF
--- a/CallOfTheWild/Main.cs
+++ b/CallOfTheWild/Main.cs
@@ -34,7 +34,7 @@ namespace CallOfTheWild
             internal Settings()
             {
 
-                using (StreamReader settings_file = File.OpenText(@"./Mods/CallOfTheWild/settings.json"))
+                using (StreamReader settings_file = File.OpenText(UnityModManager.modsPath + @"/CallOfTheWild/settings.json"))
                 using (JsonTextReader reader = new JsonTextReader(settings_file))
                 {
                     JObject jo = (JObject)JToken.ReadFrom(reader);
@@ -105,7 +105,7 @@ namespace CallOfTheWild
                 {
                     Main.DebugLog("Loading Call of the Wild");
 
-                    CallOfTheWild.LoadIcons.Image2Sprite.icons_folder = @"./Mods/CallOfTheWild/Icons/";
+                    CallOfTheWild.LoadIcons.Image2Sprite.icons_folder = UnityModManager.modsPath + @"/CallOfTheWild/Icons/";
 #if DEBUG                
                     bool allow_guid_generation = true;
 #else
@@ -276,7 +276,7 @@ namespace CallOfTheWild
                     string guid_file_name = @"C:\Repositories\KingmakerRebalance\CallOfTheWild\blueprints.txt";
                     CallOfTheWild.Helpers.GuidStorage.dump(guid_file_name);
 #endif
-                    CallOfTheWild.Helpers.GuidStorage.dump(@"./Mods/CallOfTheWild/loaded_blueprints.txt");
+                    CallOfTheWild.Helpers.GuidStorage.dump(UnityModManager.modsPath + @"/CallOfTheWild/loaded_blueprints.txt");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
CoTW is assuming Mods folder on standard Windows location (sibling of Managed). Fixed the init code to use Unit Mod Manager mod location set as a prefix to find settings, icons and loaded_blueprints.

Same issue applies for Proper Flanking and Favored Class init code.