### PR TITLE
Fix uninitialized ArmorProficiencies in PrerequisiteProficiency

### DIFF
--- a/CallOfTheWild/Classes/Mysteries/Battle.cs
+++ b/CallOfTheWild/Classes/Mysteries/Battle.cs
@@ -324,8 +324,11 @@ namespace CallOfTheWild
                                                         Common.createAddParametrizedFeatures(library.Get<BlueprintParametrizedFeature>("1e1f627d26ad36f43bbd26cc2bf8ac7e"), category), //weapon focus
                                                         Helpers.CreateAddFeatureOnClassLevel(ic_feature, 8, classes, archetypes: getArchetypeArray()),
                                                         Helpers.CreateAddFeatureOnClassLevel(gws_feature, 16, classes, archetypes: getArchetypeArray()),
-                                                        Helpers.Create<PrerequisiteProficiency>(p => p.WeaponProficiencies = new WeaponCategory[] { category })
-                                                        );
+                                                        Helpers.Create<PrerequisiteProficiency>(p =>
+                                                        {
+                                                            p.WeaponProficiencies = new WeaponCategory[] { category };
+                                                            p.ArmorProficiencies = new ArmorProficiencyGroup[0];
+                                                        }));
                 feature.AllFeatures = feature.AllFeatures.AddToArray(ws_feature);
             }
 

--- a/CallOfTheWild/Classes/ShamanSpirits/Battle.cs
+++ b/CallOfTheWild/Classes/ShamanSpirits/Battle.cs
@@ -240,8 +240,11 @@ namespace CallOfTheWild
                                                         Helpers.CreateAddStatBonus(StatType.AttackOfOpportunityCount, 1, ModifierDescriptor.UntypedStackable),
                                                         Helpers.CreateAddFeatureOnClassLevel(ws_feature, 8, hex_engine.hex_classes),
                                                         Helpers.CreateAddFeatureOnClassLevel(gws_feature, 16, hex_engine.hex_classes),
-                                                        Helpers.Create<PrerequisiteProficiency>(p => p.WeaponProficiencies = new WeaponCategory[] {category})
-                                                        );
+                                                        Helpers.Create<PrerequisiteProficiency>(p =>
+                                                        {
+                                                            p.WeaponProficiencies = new WeaponCategory[] {category};
+                                                            p.ArmorProficiencies = new Kingmaker.Blueprints.Items.Armors.ArmorProficiencyGroup[0];
+                                                        }));
                     battle_master_hex.AllFeatures = battle_master_hex.AllFeatures.AddToArray(feature);
                 }
                 battle_master_hex.AddComponent(Helpers.PrerequisiteNoFeature(battle_master_hex));

--- a/CallOfTheWild/Features/VersatilePerformance.cs
+++ b/CallOfTheWild/Features/VersatilePerformance.cs
@@ -415,8 +415,11 @@ namespace CallOfTheWild
                                                     martial_performance.Icon,
                                                     FeatureGroup.None,
                                                     Common.createAddParametrizedFeatures(library.Get<BlueprintParametrizedFeature>("1e1f627d26ad36f43bbd26cc2bf8ac7e"), category),
-                                                    Helpers.Create<PrerequisiteProficiency>(p => p.WeaponProficiencies = new WeaponCategory[] { category })
-                                                    );
+                                                    Helpers.Create<PrerequisiteProficiency>(p =>
+                                                    {
+                                                        p.WeaponProficiencies = new WeaponCategory[] { category };
+                                                        p.ArmorProficiencies = new ArmorProficiencyGroup[0];
+                                                    }));
                 martial_performance.AllFeatures = martial_performance.AllFeatures.AddToArray(feature);
             }       
         }


### PR DESCRIPTION
Caused error in:
Kingmaker.Blueprints.Classes.Prerequisites.PrerequisiteProficiency.GetUIText